### PR TITLE
add login and register ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Create a .env file in the root directory of the project and add the following va
 
 ```
 SECRET_KEY=your_secret_key
+JWT_SECRET_KEY=your_jwt_secret_key
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 TWILIO_ACCOUNT_SID=your_sid
 TWILIO_AUTH_TOKEN=your_auth_token

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv, find_dotenv
 
+
 # this looks for a .env file in the directory and loads it up load_dotenv(find_dotenv())
 
 class Config(object):
@@ -10,3 +11,7 @@ class Config(object):
     TWILIO_ACCOUNT_SID = os.environ.get('TWILIO_ACCOUNT_SID')
     TWILIO_AUTH_TOKEN = os.environ.get('TWILIO_AUTH_TOKEN')
     EXAMPLE_PHOTO_URL = os.environ.get('EXAMPLE_PHOTO_URL')
+
+
+JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY')
+JWT_TOKEN_LOCATION = ['cookies']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ python-dotenv
 flask
 flask_sqlalchemy
 flask_wtf
+flask-bcrypt
+flask-jwt-extended

--- a/templates/register.html
+++ b/templates/register.html
@@ -10,6 +10,7 @@
         <input type="email" name="email" placeholder="Email"><br>
         <input type="password" name="password" placeholder="Password"><br>
         <input type="password" name="confirm_password" placeholder="Confirm password"><br>
+        <input type="contact" name="contact" placeholder="Contact number"><br>
         <button type="submit">Create Account</button> <a href="/login">Have an account?</href>
     </form>
 </html>


### PR DESCRIPTION
Users can login/register and they are authenticated with a JWT token, which is saved in httpOnly cookie. With the cookie, users can stay logged in.

@natzhu03 To run this you need to set `JWT_SECRET_KEY` in `.env`. It's the secret used to sign the token.

---

~~Redirection to /login when the token is invalid will be in future pull requests.~~